### PR TITLE
pom.xml: adding suuport for AARCH64 architecture in

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
     <argLine.javaProperties>-D_</argLine.javaProperties>
     <!-- Configure the os-maven-plugin extension to expand the classifier on                  -->
     <!-- Fedora-"like" systems. This is currently only used for the netty-tcnative dependency -->
-    <!--<os.detection.classifierWithLikes>fedora</os.detection.classifierWithLikes> -->
+    <os.detection.classifierWithLikes>fedora</os.detection.classifierWithLikes>
     <tcnative.artifactId>netty-tcnative</tcnative.artifactId>
     <tcnative.version>2.0.8.Final</tcnative.version>
     <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>

--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
     <argLine.javaProperties>-D_</argLine.javaProperties>
     <!-- Configure the os-maven-plugin extension to expand the classifier on                  -->
     <!-- Fedora-"like" systems. This is currently only used for the netty-tcnative dependency -->
-    <os.detection.classifierWithLikes>fedora</os.detection.classifierWithLikes>
+    <!--<os.detection.classifierWithLikes>fedora</os.detection.classifierWithLikes> -->
     <tcnative.artifactId>netty-tcnative</tcnative.artifactId>
     <tcnative.version>2.0.8.Final</tcnative.version>
     <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
@@ -602,10 +602,11 @@
                 </requireMavenVersion>
                 <requireProperty>
                   <regexMessage>
-                    x86_64 JDK must be used.
+                    x86_64/aarch64 JDK must be used.
                   </regexMessage>
                   <property>os.detected.arch</property>
                   <regex>^x86_64$</regex>
+                  <regex>^aarch_64$</regex>
                 </requireProperty>
               </rules>
             </configuration>


### PR DESCRIPTION
Netty/Transport/Native/Epoll

AARCH 64 architecture support was missing in the exiting Netty-epoll code.
Now the Netty/Transport/Native/Epoll project can be used in aarch64 platform.